### PR TITLE
✨ feat(pihole-unbound): Add volume and expose Unbound port

### DIFF
--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -4,8 +4,11 @@ FROM pihole/pihole:2024.07.0
 # Set environment variables for Unbound installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update package list, install Unbound
-RUN apt-get update && apt-get install -y --no-install-recommends unbound
+# Update package list, install Unbound and clean up in one layer
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unbound && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create the Unbound service directory
 RUN mkdir -p /etc/services.d/unbound
@@ -31,10 +34,16 @@ COPY pihole/setupVars.conf /etc/pihole/setupVars.conf
 RUN chown -R www-data:www-data /etc/pihole && \
     chmod -R 755 /etc/pihole
 
+# Add a volume for Unbound configuration
+VOLUME ["/etc/unbound"]
+
+# Expose Unbound DNS port
+EXPOSE 5353/tcp 5353/udp
+
 # Entrypoint
 ENTRYPOINT ./s6-init
 
 # Healthcheck for Pi-hole and Unbound
-HEALTHCHECK --interval=1m --timeout=10s \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD dig +short @127.0.0.1 -p 53 pi.hole || exit 1; \
   dig +short @127.0.0.1 -p 5353 example.com || exit 1

--- a/pihole-unbound/unbound/unbound_run_script
+++ b/pihole-unbound/unbound/unbound_run_script
@@ -1,5 +1,4 @@
 #!/command/with-contenv bash
-# Exit immediately if a command exits with a non-zero status.
 set -e
 
 # Enable debugging if needed
@@ -16,14 +15,10 @@ LOGFILE="$LOGDIR/unbound.log"
 HELPER="/usr/lib/unbound/package-helper"
 
 # Ensure the Unbound log directory exists
-if [ ! -d "$LOGDIR" ]; then
-    mkdir -p "$LOGDIR"
-fi
+mkdir -p "$LOGDIR"
 
 # Ensure the Unbound log file exists
-if [ ! -f "$LOGFILE" ]; then
-    touch "$LOGFILE"
-fi
+touch "$LOGFILE"
 
 # Ensure the Unbound binary is executable
 if [ ! -x "$DAEMON" ]; then
@@ -44,20 +39,4 @@ $HELPER root_trust_anchor_update >> "$LOGFILE" 2>&1
 
 # Start Unbound
 s6-echo "Running Unbound with options: $DAEMON_OPTS"
-$DAEMON -d $DAEMON_OPTS >> "$LOGFILE" 2>&1 &
-
-echo $! > "$PIDFILE"
-
-# Simple check to see if Unbound started
-if ! pgrep -F "$PIDFILE" > /dev/null; then
-    s6-echo "Unbound failed to start."
-    exit 1
-fi
-
-s6-echo "Unbound started successfully with PID $(cat $PIDFILE)"
-
-# Trap SIGTERM and SIGINT to perform a clean shutdown
-trap 's6-echo "Stopping Unbound"; kill $(cat $PIDFILE); wait $(cat $PIDFILE); exit 0;' SIGTERM SIGINT
-
-# Wait for Unbound to exit
-wait $(cat $PIDFILE)
+exec $DAEMON -d $DAEMON_OPTS >> "$LOGFILE" 2>&1


### PR DESCRIPTION
This commit adds a volume for the Unbound configuration and exposes the Unbound DNS port (5353/tcp and 5353/udp) in the Dockerfile. It also improves the healthcheck by reducing the interval, adding a start period, and increasing the number of retries.

The changes in the `unbound_run_script` file simplify the script by removing unnecessary checks and using `exec` to run Unbound, which allows for proper signal handling and process management.