### PR TITLE
🔧 refactor(apps): update docs_link in config.json files

### DIFF
--- a/Apps/pihole-unbound/config.json
+++ b/Apps/pihole-unbound/config.json
@@ -4,5 +4,5 @@
   "version": "2025.02.1",
   "image": "bigbeartechworld/big-bear-pihole-unbound",
   "youtube": "https://www.youtube.com/playlist?list=PL2RAscIdkpt_21TJEBkhIm52aU-w3K4vi",
-  "docs_link": "[Documentation](https://community.bigbeartechworld.com/t/added-pihole-and-unbound-to-bigbeardockerimages/192)"
+  "docs_link": "https://community.bigbeartechworld.com/t/added-pihole-and-unbound-to-bigbeardockerimages/192"
 }

--- a/Apps/pocketbase/config.json
+++ b/Apps/pocketbase/config.json
@@ -4,5 +4,5 @@
   "version": "0.22.21",
   "image": "bigbeartechworld/big-bear-pocketbase",
   "youtube": "",
-  "docs_link": "[Documentation](https://community.bigbeartechworld.com/t/pocketbase-is-on-bigbeardockerimages/28)"
+  "docs_link": "https://community.bigbeartechworld.com/t/pocketbase-is-on-bigbeardockerimages/28"
 }


### PR DESCRIPTION
**Refactor: Update docs_link in config.json files**

The changes update the `docs_link` field in the `config.json` files for the `pihole-unbound` and `pocketbase` apps. The links are now provided as plain URLs instead of using Markdown syntax for the documentation links.

<###>🔧 refactor(apps): update docs_link in config.json files

The changes update the `docs_link` field in the `config.json` files for the `pihole-unbound` and `pocketbase` apps. The links are now provided as plain URLs instead of using Markdown syntax for the documentation links.