### PR TITLE
🔒 feat(Apps/fastfetch): Add authentication support for gotty and ttyd

### DIFF
--- a/Apps/fastfetch/Dockerfile
+++ b/Apps/fastfetch/Dockerfile
@@ -22,10 +22,23 @@ RUN git clone https://github.com/sorenisanerd/gotty.git /tmp/gotty && \
     rm -rf /tmp/gotty
 
 # Set the terminal to support UTF-8
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
+
+# Set default authentication (can be overridden at runtime)
+# Note: These values should be overridden at runtime for security
+ARG GOTTY_AUTH_USER=bigbear
+ARG GOTTY_AUTH_PASS=password
+ARG GOTTY_AUTH_ENABLED=false
+ENV GOTTY_AUTH_USER=${GOTTY_AUTH_USER}
+ENV GOTTY_AUTH_PASS=${GOTTY_AUTH_PASS}
+ENV GOTTY_AUTH_ENABLED=${GOTTY_AUTH_ENABLED}
 
 # Expose the port gotty will run on
 EXPOSE 7681
 
-# Start gotty and run fastfetch
-CMD ["gotty", "-p", "7681", "-w", "fastfetch"]
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Apps/fastfetch/Dockerfile.ttyd
+++ b/Apps/fastfetch/Dockerfile.ttyd
@@ -27,10 +27,23 @@ RUN git clone https://github.com/tsl0922/ttyd.git /tmp/ttyd && \
     rm -rf /tmp/ttyd
 
 # Set the terminal to support UTF-8
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
+
+# Set default authentication (can be overridden at runtime)
+# Note: These values should be overridden at runtime for security
+ARG TTYD_AUTH_USER=bigbear
+ARG TTYD_AUTH_PASS=password
+ARG TTYD_AUTH_ENABLED=false
+ENV TTYD_AUTH_USER=${TTYD_AUTH_USER}
+ENV TTYD_AUTH_PASS=${TTYD_AUTH_PASS}
+ENV TTYD_AUTH_ENABLED=${TTYD_AUTH_ENABLED}
 
 # Expose the port ttyd will run on
 EXPOSE 7681
 
-# Start ttyd and run btop
-CMD ["ttyd", "-p", "7681", "-W", "fastfetch"]
+# Copy entrypoint script
+COPY entrypoint.ttyd.sh /entrypoint.ttyd.sh
+RUN chmod +x /entrypoint.ttyd.sh
+
+# Set entrypoint
+ENTRYPOINT ["/entrypoint.ttyd.sh"]

--- a/Apps/fastfetch/docker-compose.yml
+++ b/Apps/fastfetch/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     build: .
     # Name the container 'big-bear-fastfetch' for easier identification
     container_name: big-bear-fastfetch
+    # Environment variables for authentication
+    environment:
+      - GOTTY_AUTH_USER=bigbear
+      - GOTTY_AUTH_PASS=password
+      - GOTTY_AUTH_ENABLED=true
     # Run the container in privileged mode to allow access to system metrics
     privileged: true
     # Mount necessary volumes for accessing system information

--- a/Apps/fastfetch/entrypoint.sh
+++ b/Apps/fastfetch/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Set HOME to root to ensure the correct configuration path
+export HOME=/root
+
+# Check if authentication is enabled
+if [ "$GOTTY_AUTH_ENABLED" = "true" ]; then
+    # Execute command with authentication (using quoted arguments for security)
+    exec gotty -p 7681 -w -c "${GOTTY_AUTH_USER}:${GOTTY_AUTH_PASS}" fastfetch
+else
+    # Execute the provided command without authentication
+    if [ $# -eq 0 ]; then
+        # No command provided, use default
+        exec gotty -p 7681 -w fastfetch
+    else
+        # Use provided command
+        exec "$@"
+    fi
+fi

--- a/Apps/fastfetch/entrypoint.ttyd.sh
+++ b/Apps/fastfetch/entrypoint.ttyd.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Set HOME to root to ensure the correct configuration path
+export HOME=/root
+
+# Check if authentication is enabled
+if [ "$TTYD_AUTH_ENABLED" = "true" ]; then
+    # Execute command with authentication (using quoted arguments for security)
+    exec ttyd -p 7681 -W -c "${TTYD_AUTH_USER}:${TTYD_AUTH_PASS}" fastfetch
+else
+    # Execute the provided command without authentication
+    if [ $# -eq 0 ]; then
+        # No command provided, use default
+        exec ttyd -p 7681 -W fastfetch
+    else
+        # Use provided command
+        exec "$@"
+    fi
+fi


### PR DESCRIPTION
🔒 feat(Apps/fastfetch): Add authentication support for gotty and ttyd

This pull request adds support for authentication to the gotty and ttyd containers in the fastfetch application. The changes include:

<###>🔒 feat(Apps/fastfetch): Add authentication support for gotty and ttyd

This commit adds support for authentication to the gotty and ttyd containers in the
fastfetch application. The changes include:

- Added environment variables for configuring the authentication user, password, and
  enabling/disabling authentication in the Dockerfile and docker-compose.yml file.
- Created custom entrypoint scripts (entrypoint.sh and entrypoint.ttyd.sh) to handle
  the authentication logic and execute the respective commands (gotty or ttyd) with
  or without authentication based on the environment variables.
- Updated the Dockerfile to copy the entrypoint scripts and set them as the entrypoint.

These changes allow the fastfetch application to be run with or without authentication,
providing an additional layer of security for the system metrics and information
displayed in the web-based terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced container startup with secure, script-driven initialization.
	- Introduced configurable runtime authentication options for added security.
	- Updated service deployment settings to allow easy customization of access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->