### PR TITLE
🔒 feat(authentication): Add authentication support for NCDU container

### DIFF
--- a/Apps/ncdu/Dockerfile
+++ b/Apps/ncdu/Dockerfile
@@ -25,13 +25,26 @@ RUN apk add --no-cache \
 COPY --from=builder /gotty/gotty /usr/local/bin/gotty
 
 # Set the terminal to support UTF-8
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # Define the NCDU_PATH environment variable with a default value
-ENV NCDU_PATH /
+ENV NCDU_PATH=/
+
+# Set default authentication (can be overridden at runtime)
+# Note: These values should be overridden at runtime for security
+ARG GOTTY_AUTH_USER=bigbear
+ARG GOTTY_AUTH_PASS=password
+ARG GOTTY_AUTH_ENABLED=false
+ENV GOTTY_AUTH_USER=${GOTTY_AUTH_USER}
+ENV GOTTY_AUTH_PASS=${GOTTY_AUTH_PASS}
+ENV GOTTY_AUTH_ENABLED=${GOTTY_AUTH_ENABLED}
 
 # Expose the port gotty will run on
 EXPOSE 7681
 
-# Start gotty and run ncdu with the specified path
-CMD gotty -p 7681 -w ncdu $NCDU_PATH
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Apps/ncdu/Dockerfile.ttyd
+++ b/Apps/ncdu/Dockerfile.ttyd
@@ -26,13 +26,26 @@ RUN git clone https://github.com/tsl0922/ttyd.git /tmp/ttyd && \
     rm -rf /tmp/ttyd
 
 # Set the terminal to support UTF-8
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # Define the NCDU_PATH environment variable with a default value
-ENV NCDU_PATH /
+ENV NCDU_PATH=/
+
+# Set default authentication (can be overridden at runtime)
+# Note: These values should be overridden at runtime for security
+ARG TTYD_AUTH_USER=bigbear
+ARG TTYD_AUTH_PASS=password
+ARG TTYD_AUTH_ENABLED=false
+ENV TTYD_AUTH_USER=${TTYD_AUTH_USER}
+ENV TTYD_AUTH_PASS=${TTYD_AUTH_PASS}
+ENV TTYD_AUTH_ENABLED=${TTYD_AUTH_ENABLED}
 
 # Expose the port ttyd will run on
 EXPOSE 7681
 
-# Start ttyd and run btop
-CMD ["ttyd", "-p", "7681", "-W", "ncdu", "$NCDU_PATH"]
+# Copy entrypoint script
+COPY entrypoint.ttyd.sh /entrypoint.ttyd.sh
+RUN chmod +x /entrypoint.ttyd.sh
+
+# Set entrypoint
+ENTRYPOINT ["/entrypoint.ttyd.sh"]

--- a/Apps/ncdu/docker-compose.yml
+++ b/Apps/ncdu/docker-compose.yml
@@ -7,6 +7,12 @@ services:
     build: .
     # Name the container 'big-bear-ncdu' for easier identification
     container_name: big-bear-ncdu
+    # Environment variables for authentication
+    environment:
+      - NCDU_PATH=/
+      - GOTTY_AUTH_USER=bigbear
+      - GOTTY_AUTH_PASS=password
+      - GOTTY_AUTH_ENABLED=true
     # Run the container in privileged mode to allow access to system metrics
     privileged: true
     # Mount necessary volumes for accessing system information
@@ -19,9 +25,6 @@ services:
       - /dev:/dev
       # Mount the host's /etc/localtime file to the container's /etc/localtime file (read-only)
       - /etc/localtime:/etc/localtime:ro
-    # Set environment variables for the container
-    environment:
-      - NCDU_PATH=/
     # Map port 7681 on the host to port 7681 on the container
     ports:
       - "7681:7681"

--- a/Apps/ncdu/entrypoint.sh
+++ b/Apps/ncdu/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Set HOME to root to ensure the correct configuration path
+export HOME=/root
+
+# Check if authentication is enabled
+if [ "$GOTTY_AUTH_ENABLED" = "true" ]; then
+    # Execute command with authentication (using quoted arguments for security)
+    exec gotty -p 7681 -w -c "${GOTTY_AUTH_USER}:${GOTTY_AUTH_PASS}" ncdu "${NCDU_PATH}"
+else
+    # Execute the provided command without authentication
+    if [ $# -eq 0 ]; then
+        # No command provided, use default
+        exec gotty -p 7681 -w ncdu "${NCDU_PATH}"
+    else
+        # Use provided command
+        exec "$@"
+    fi
+fi

--- a/Apps/ncdu/entrypoint.ttyd.sh
+++ b/Apps/ncdu/entrypoint.ttyd.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Set HOME to root to ensure the correct configuration path
+export HOME=/root
+
+# Check if authentication is enabled
+if [ "$TTYD_AUTH_ENABLED" = "true" ]; then
+    # Execute command with authentication (using quoted arguments for security)
+    exec ttyd -p 7681 -W -c "${TTYD_AUTH_USER}:${TTYD_AUTH_PASS}" ncdu "${NCDU_PATH}"
+else
+    # Execute the provided command without authentication
+    if [ $# -eq 0 ]; then
+        # No command provided, use default
+        exec ttyd -p 7681 -W ncdu "${NCDU_PATH}"
+    else
+        # Use provided command
+        exec "$@"
+    fi
+fi


### PR DESCRIPTION
This pull request adds support for authentication in the NCDU container. The key changes include:

- Added environment variables for authentication in the `docker-compose.yml` file.
- Defined default authentication values in the Dockerfiles, which can be overridden at runtime.
- Implemented authentication logic in the `entrypoint.sh` and `entrypoint.ttyd.sh` scripts.
- The authentication can be enabled or disabled by setting the `GOTTY_AUTH_ENABLED` or `TTYD_AUTH_ENABLED` environment variables.

These changes allow the NCDU container to be secured with a username and password, improving the overall security of the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced customizable authentication options with new parameters for secure runtime configuration.
  - Implemented dedicated entrypoint scripts to streamline the container startup process.

- **Chores**
  - Updated container environment settings and configuration assignments for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->