### PR TITLE
fix(ci): make bot-merged version bumps build and publish

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,11 +21,11 @@ jobs:
   automerge:
     env:
       MERGE_METHOD: "squash"
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      GITHUB_TOKEN: "${{ secrets.PERSONAL_TOKEN }}"
     runs-on: ubuntu-latest
     steps:
       - id: automerge
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PERSONAL_TOKEN }}"

--- a/.github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml
+++ b/.github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for big-bear-casaos-user-management"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_btop.yaml
+++ b/.github/workflows/build_and_release_for_btop.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for btop"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_fastfetch.yaml
+++ b/.github/workflows/build_and_release_for_fastfetch.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for fastfetch"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_genmon.yaml
+++ b/.github/workflows/build_and_release_for_genmon.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for genmon"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_ncdu.yaml
+++ b/.github/workflows/build_and_release_for_ncdu.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for ncdu"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml
+++ b/.github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for nextcloud-with-smbclient"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_pihole_unbound.yaml
+++ b/.github/workflows/build_and_release_for_pihole_unbound.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for pihole-unbound"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_pocketbase.yaml
+++ b/.github/workflows/build_and_release_for_pocketbase.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for pocketbase"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Auto-merge used GITHUB_TOKEN, whose pushes don't trigger workflows, so bot-merged bumps (incl. pihole-unbound 2026.05.0) never built. Switched automerge to PERSONAL_TOKEN.

Added workflow_dispatch to build workflows so stuck images can be rebuilt manually.

Backfill needed after merge: pihole-unbound 2026.05.0, btop 0.1.7, ncdu 0.0.6, nextcloud-with-smbclient 33.0.3, genmon 2.0.01.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a GitHub Actions limitation where merges performed with the built-in `GITHUB_TOKEN` do not trigger other workflows — bot-merged version bumps were silently skipped. The fix switches the `automerge-action` to use `PERSONAL_TOKEN` and adds a `workflow_dispatch` trigger to eight build workflows so that stuck images can be manually rebuilt.

- **`auto-merge.yml`**: Replaces `GITHUB_TOKEN` with `PERSONAL_TOKEN` at both the job and step `env` scopes, ensuring that bot-merged pushes to `main` propagate to downstream build workflows.
- **8 build workflows** (`btop`, `fastfetch`, `genmon`, `ncdu`, `nextcloud-with-smbclient`, `pihole-unbound`, `pocketbase`, `casaos-user-management`): Each gains a bare `workflow_dispatch` trigger so operators can manually re-run a skipped build; the two remaining workflows (`minio`, `unbound`) already had `workflow_dispatch` with version inputs.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the automerge token switch correctly unblocks bot-merged version bumps, and the workflow_dispatch additions are low-risk one-liners.

The core change is well-understood: switching from the built-in token to a PAT for automerge is the standard solution for enabling push-triggered workflows. PERSONAL_TOKEN is already used elsewhere in the repo (e.g., unbound's create-update-pr job), so the secret should already be configured. The only notable gap is that the eight new workflow_dispatch triggers carry no inputs, meaning operators cannot target a specific version on manual dispatch — they must ensure the VERSION file is correct first. This makes the backfill story slightly fragile but is not a blocker.

The eight build workflow files all share the same inputless workflow_dispatch pattern; auto-merge.yml is the most impactful change and is straightforward.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-merge.yml | Switches automerge from GITHUB_TOKEN to PERSONAL_TOKEN at both job and step level to allow bot-merged pushes to trigger downstream workflows |
| .github/workflows/build_and_release_for_btop.yaml | Adds workflow_dispatch trigger with no inputs; builds whatever version is currently in the repo's VERSION file |
| .github/workflows/build_and_release_for_pihole_unbound.yaml | Adds workflow_dispatch trigger with no inputs to allow manual backfill builds |
| .github/workflows/build_and_release_for_ncdu.yaml | Adds workflow_dispatch trigger with no inputs |
| .github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml | Adds workflow_dispatch trigger with no inputs |
| .github/workflows/build_and_release_for_genmon.yaml | Adds workflow_dispatch trigger with no inputs |
| .github/workflows/build_and_release_for_fastfetch.yaml | Adds workflow_dispatch trigger with no inputs |
| .github/workflows/build_and_release_for_pocketbase.yaml | Adds workflow_dispatch trigger with no inputs |
| .github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml | Adds workflow_dispatch trigger with no inputs |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Bot as Dependabot/Bot
    participant GH as GitHub
    participant AM as automerge-action
    participant BW as Build Workflow

    Bot->>GH: Open version-bump PR
    GH->>AM: pull_request event (labeled/opened)
    AM->>GH: Merge PR using PERSONAL_TOKEN
    Note over AM,GH: Before: used GITHUB_TOKEN (pushes don't trigger other workflows)
    Note over AM,GH: After: uses PERSONAL_TOKEN (pushes do trigger other workflows)
    GH->>BW: push event fires (main branch)
    BW->>GH: Build and publish Docker image

    Note over GH,BW: workflow_dispatch added for manual backfills
    actor Dev as Developer
    Dev->>GH: Trigger workflow_dispatch
    GH->>BW: Manual build triggered
    BW->>GH: Build and publish missed image
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/build_and_release_for_btop.yaml:3-7
The `workflow_dispatch` trigger is added without any `inputs`, so when triggered manually there is no way to specify a version — the workflow will always build whatever is currently in the repository's `VERSION` file. The PR description lists specific versions that need backfilling (e.g., btop 0.1.7), so if the `VERSION` file has already moved to a newer release the backfill won't produce the intended tag. Adding an optional `version` input (matching the pattern used in `build_and_release_for_minio.yaml` and `build_and_release_for_unbound.yaml`) would make manual re-runs more flexible. The same applies to all 8 workflows updated in this PR.

```suggestion
on:
  workflow_dispatch:
    inputs:
      version:
        description: 'Version to build (leave empty to use current VERSION file)'
        required: false
        default: ''
  push:
    branches:
      - main
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make bot-merged version bumps b..."](https://github.com/bigbeartechworld/big-bear-docker-images/commit/f2b0a49d93c92e1fa37cd5f737e247ebee667648) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34588910)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->