### PR TITLE
fix(ci): make bot-merged version bumps build and publish

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,11 +21,11 @@ jobs:
   automerge:
     env:
       MERGE_METHOD: "squash"
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      GITHUB_TOKEN: "${{ secrets.PERSONAL_TOKEN }}"
     runs-on: ubuntu-latest
     steps:
       - id: automerge
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PERSONAL_TOKEN }}"

--- a/.github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml
+++ b/.github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for big-bear-casaos-user-management"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml
+++ b/.github/workflows/build_and_release_for_big_bear_casaos_user_management.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "big_bear_casaos_user_management_version=$(cat Apps/big-bear-casaos-user-management/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/big-bear-casaos-user-management/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "big_bear_casaos_user_management_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_btop.yaml
+++ b/.github/workflows/build_and_release_for_btop.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "btop_version=$(cat Apps/btop/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/btop/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "btop_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_btop.yaml
+++ b/.github/workflows/build_and_release_for_btop.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for btop"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_fastfetch.yaml
+++ b/.github/workflows/build_and_release_for_fastfetch.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for fastfetch"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_fastfetch.yaml
+++ b/.github/workflows/build_and_release_for_fastfetch.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "fastfetch_version=$(cat Apps/fastfetch/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/fastfetch/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "fastfetch_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_genmon.yaml
+++ b/.github/workflows/build_and_release_for_genmon.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "genmon_version=$(cat Apps/genmon/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/genmon/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "genmon_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_genmon.yaml
+++ b/.github/workflows/build_and_release_for_genmon.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for genmon"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_ncdu.yaml
+++ b/.github/workflows/build_and_release_for_ncdu.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "ncdu_version=$(cat Apps/ncdu/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/ncdu/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "ncdu_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_ncdu.yaml
+++ b/.github/workflows/build_and_release_for_ncdu.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for ncdu"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml
+++ b/.github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "nextcloud_with_smbclient_version=$(cat Apps/nextcloud-with-smbclient/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/nextcloud-with-smbclient/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "nextcloud_with_smbclient_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml
+++ b/.github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for nextcloud-with-smbclient"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_pihole_unbound.yaml
+++ b/.github/workflows/build_and_release_for_pihole_unbound.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for pihole-unbound"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_pihole_unbound.yaml
+++ b/.github/workflows/build_and_release_for_pihole_unbound.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -24,7 +27,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "pihole_unbound_version=$(cat Apps/pihole-unbound/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/pihole-unbound/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "pihole_unbound_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/build_and_release_for_pocketbase.yaml
+++ b/.github/workflows/build_and_release_for_pocketbase.yaml
@@ -1,6 +1,7 @@
 name: "Build and release for pocketbase"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_and_release_for_pocketbase.yaml
+++ b/.github/workflows/build_and_release_for_pocketbase.yaml
@@ -12,6 +12,9 @@ jobs:
   create:
     name: "Creates the newest release by version"
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout project
@@ -20,7 +23,10 @@ jobs:
       # New step to read the VERSION file and set the version as an output
       - name: Get the version
         id: get_version
-        run: echo "pocketbase_version=$(cat Apps/pocketbase/VERSION)" >> $GITHUB_ENV
+        run: |
+          VERSION=$(tr -d '\n\r' < Apps/pocketbase/VERSION)
+          [[ "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]] || { echo "Invalid VERSION: $VERSION"; exit 1; }
+          echo "pocketbase_version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master


### PR DESCRIPTION
Closes #199

Auto-merge used GITHUB_TOKEN, whose pushes don't trigger workflows, so bot-merged bumps (incl. pihole-unbound 2026.05.0) never built. Switched automerge to PERSONAL_TOKEN.

Added workflow_dispatch to build workflows so stuck images can be rebuilt manually.

Backfill needed after merge: pihole-unbound 2026.05.0, btop 0.1.7, ncdu 0.0.6, nextcloud-with-smbclient 33.0.3, genmon 2.0.01.

---

### Security review notes

- **Dispatch builds restricted to main** — added `if: github.ref == 'refs/heads/main'` so manual `workflow_dispatch` runs (which hold DockerHub push creds) cannot run from arbitrary branches. Added `permissions: contents: read` and VERSION-file validation to the build jobs.
- **automerge uses PERSONAL_TOKEN (accepted)** — required so merge pushes trigger downstream builds; `GITHUB_TOKEN` pushes do not. PERSONAL_TOKEN is already used repo-wide by every create-pull-request step, so this adds no new secret/scope. Future hardening: replace the PAT with a repo-scoped GitHub App installation token (maintainer infra).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes bot-merged version bumps that never triggered build workflows because `GITHUB_TOKEN`-authored pushes are intentionally ignored by GitHub's event system. It also adds `workflow_dispatch` to all 8 build workflows so stuck images can be manually rebuilt.

- **`auto-merge.yml`**: Swapped `GITHUB_TOKEN` for `PERSONAL_TOKEN` in both env blocks so automerge-generated pushes now fire `push` events and trigger downstream builds.
- **Build workflows (8 files)**: Added `workflow_dispatch` trigger with a job-level `if: github.ref == 'refs/heads/main'` guard to prevent accidental pushes from non-main branches; also added `permissions: contents: read` and hardened VERSION reading with `tr -d '\n\r'` plus a regex sanity check that fails fast on malformed values.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is targeted and correct, and the workflow_dispatch guard reliably restricts manual runs to the main branch.

The root-cause fix (PERSONAL_TOKEN replacing GITHUB_TOKEN) is correct and well-understood. The `if: github.ref == 'refs/heads/main'` job condition properly addresses the manual-dispatch branch concern from a prior review round. VERSION validation is a net improvement. No new logic paths introduce incorrect behavior.

No files require special attention. The auto-merge.yml change is the most impactful but is a one-line token swap applied consistently in both env blocks.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-merge.yml | Replaced GITHUB_TOKEN with PERSONAL_TOKEN in both job-level and step-level env; fixes the root cause where GitHub-token-authored pushes don't trigger downstream workflows |
| .github/workflows/build_and_release_for_btop.yaml | Added workflow_dispatch trigger, job-level main-branch guard (if: github.ref == 'refs/heads/main'), permissions: contents: read, and VERSION validation with regex; all changes are correct |
| .github/workflows/build_and_release_for_pihole_unbound.yaml | Identical structural changes as btop: workflow_dispatch, main guard, permissions, VERSION validation — no issues; this was the originally blocked image |
| .github/workflows/build_and_release_for_pocketbase.yaml | Identical structural changes as btop: workflow_dispatch, main guard, permissions, VERSION validation — no issues |
| .github/workflows/build_and_release_for_nextcloud_with_smbclient.yaml | Identical structural changes as btop: workflow_dispatch, main guard, permissions, VERSION validation — no issues |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Bot as Dependabot/Bot PR
    participant AM as auto-merge.yml
    participant PT as PERSONAL_TOKEN (PAT)
    participant GH as GitHub (push event)
    participant BW as Build Workflow

    Bot->>AM: PR labeled / checks complete
    AM->>PT: Authenticate with PERSONAL_TOKEN
    PT->>GH: Squash-merge to main
    Note over GH: PAT push DOES trigger workflows
    GH->>BW: push event on main (paths filter)
    BW->>BW: "if: github.ref == 'refs/heads/main' ✓"
    BW->>BW: "Read & validate VERSION file"
    BW->>BW: "Docker build & push to DockerHub"

    Note over BW: Manual backfill path
    actor Dev as Developer
    Dev->>BW: workflow_dispatch (selects branch)
    BW->>BW: "if: github.ref == 'refs/heads/main'?"
    alt branch is main
        BW->>BW: "Proceed — build & push"
    else branch is not main
        BW->>BW: Job skipped
    end
```

<sub>Reviews (2): Last reviewed commit: ["harden(ci): restrict dispatch builds to ..."](https://github.com/bigbeartechworld/big-bear-docker-images/commit/94295bb1dbcb65334d58fb7eeec466dd0d3478eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34589183)</sub>

<!-- /greptile_comment -->